### PR TITLE
item filter: Use respective colors for scrolls

### DIFF
--- a/doc/ENG/item.filter
+++ b/doc/ENG/item.filter
@@ -625,12 +625,12 @@ Continue
 
 Show
     Type Scroll of Identify
-    SetName {Blue}* {White}ID
+    SetName {Red}* {White}ID
 Continue
 
 Show
     Type Scroll of Town Portal
-    SetName {Green}* {White}TP
+    SetName {Blue}* {White}TP
 Continue
 
 Show


### PR DESCRIPTION
Using the in-game visual item colors for the scrolls is likely going to be less confusing for most users